### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/content/blog/ai-MULTIAGENTS-TOOLS.md
+++ b/content/blog/ai-MULTIAGENTS-TOOLS.md
@@ -393,7 +393,7 @@ We introduce the most common ones here:
 
 Advanced Concepts: AG2 supports more concepts such as structured outputs, rag, code execution, etc.
 
-* https://pypi.org/project/pyautogen/
+* https://pypi.org/project/ag2/
 * https://github.com/ag2ai/ag2
 
 ```sh

--- a/content/blog/aigen-dev-autogen.md
+++ b/content/blog/aigen-dev-autogen.md
@@ -47,12 +47,12 @@ They can operate in various modes that employ combinations of LLMs, human inputs
 
 <!-- The [Autogen Project]() and the code is [Open Source](). -->
 
-The Autogen package in [PyPI](https://pypi.org/project/pyautogen/).
+The Autogen package in [PyPI](https://pypi.org/project/ag2/).
 
 
 ```sh
-pip install pyautogen==0.1.14
-#pip show pyautogen
+pip install ag2==0.1.14
+#pip show ag2
 
 
 pip install --upgrade streamlit reflex


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
